### PR TITLE
Make various fixes throughout the code, use separate logging using Python logging

### DIFF
--- a/image_creator/constants.py
+++ b/image_creator/constants.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015 Vangelis Koukis <vkoukis@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Various constants used throughout snf-image-creator"""
+
+DEFAULT_LOGFILE = "/var/log/snf-image-creator.log"
+
+# vim: set sta sts=4 shiftwidth=4 sw=4 et ai :

--- a/image_creator/dialog_main.py
+++ b/image_creator/dialog_main.py
@@ -46,13 +46,13 @@ from image_creator.dialog_util import WIDTH, confirm_exit, Reset, \
 PROGNAME = os.path.basename(sys.argv[0])
 
 
-def create_image(d, media, out, tmp, snapshot):
-    """Create an image out of `media'"""
+def create_image(d, medium, out, tmp, snapshot):
+    """Create an image out of `medium'"""
     d.setBackgroundTitle('snf-image-creator')
 
     gauge = GaugeOutput(d, "Initialization", "Initializing...")
     out.append(gauge)
-    disk = Disk(media, out, tmp)
+    disk = Disk(medium, out, tmp)
 
     def signal_handler(signum, frame):
         gauge.cleanup()
@@ -83,7 +83,7 @@ def create_image(d, media, out, tmp, snapshot):
             session['excluded_tasks'] = [-1]
             session['task_metadata'] = ["EXCLUDE_ALL_TASKS"]
 
-            msg = "The system on the input media is not supported." \
+            msg = "The system on the input medium is not supported." \
                 "\n\nReason: %s\n\n" \
                 "We highly recommend not to create an image out of this, " \
                 "since the image won't be cleaned up and you will not be " \
@@ -97,7 +97,7 @@ def create_image(d, media, out, tmp, snapshot):
             d.infobox("Thank you for using snf-image-creator. Bye", width=53)
             return 0
 
-        msg = "snf-image-creator detected a %s system on the input media. " \
+        msg = "snf-image-creator detected a %s system on the input medium. " \
               "Would you like to run a wizard to assist you through the " \
               "image creation process?\n\nChoose <Wizard> to run the wizard," \
               " <Expert> to run snf-image-creator in expert mode or press " \
@@ -161,7 +161,7 @@ def _dialog_form(self, text, height=20, width=60, form_height=15, fields=[],
     return (code, output.splitlines())
 
 
-def dialog_main(media, **kwargs):
+def dialog_main(medium, **kwargs):
     """Main function for the dialog-based version of the program"""
 
     tmpdir = kwargs['tmpdir'] if 'tmpdir' in kwargs else None
@@ -197,13 +197,13 @@ def dialog_main(media, **kwargs):
 
     d.setBackgroundTitle('snf-image-creator')
 
-    # Pick input media
+    # Pick input medium
     while True:
-        media = select_file(d, init=media, ftype="br", bundle_host=True,
-                            title="Please select an input media.")
-        if media is None:
+        medium = select_file(d, init=medium, ftype="br", bundle_host=True,
+                            title="Please select an input medium.")
+        if medium is None:
             if confirm_exit(
-                    d, "You canceled the media selection dialog box."):
+                    d, "You canceled the medium selection dialog box."):
                 return 0
             continue
         break
@@ -222,7 +222,7 @@ def dialog_main(media, **kwargs):
             try:
                 out = CompositeOutput(logs)
                 out.info("Starting %s v%s ..." % (PROGNAME, version))
-                ret = create_image(d, media, out, tmpdir, snapshot)
+                ret = create_image(d, medium, out, tmpdir, snapshot)
                 break
             except Reset:
                 for log in logs:
@@ -245,14 +245,14 @@ def dialog_main(media, **kwargs):
 
 def main():
     """Entry Point"""
-    d = ("Create a cloud Image from the specified INPUT_MEDIA."
-         " INPUT_MEDIA must be the hard disk of an existing OS deployment"
+    d = ("Create a cloud Image from the specified INPUT_MEDIUM."
+         " INPUT_MEDIUM must be the hard disk of an existing OS deployment"
          " to be used as the template for Image creation. Supported formats"
          " include raw block devices, all disk image file formats supported"
          " by QEMU (e.g., QCOW2, VMDK, VDI, VHD), or the filesystem of the"
          " host itself. The resulting Image is meant to be used with Synnefo"
          " and other IaaS cloud platforms. Note this program works on a"
-         " snapshot of INPUT_MEDIA, and will not modify its contents.")
+         " snapshot of INPUT_MEDIUM, and will not modify its contents.")
     e = ("%(prog)s requires root privileges.")
 
     parser = argparse.ArgumentParser(version=version, description=d, epilog=e)
@@ -268,12 +268,12 @@ def main():
     parser.add_argument("--no-snapshot", dest="snapshot", default=True,
                         action="store_false",
                         help=("Do not work on a snapshot, but modify the input"
-                              " media directly instead. DO NOT USE THIS OPTION"
-                              " UNLESS YOU REALLY KNOW WHAT YOU ARE DOING."
-                             " THIS WILL ALTER THE ORIGINAL MEDIA!"))
-    parser.add_argument(metavar="INPUT_MEDIA",
-                        nargs='?', dest="media", type=str, default=None,
-                        help=("Use INPUT_MEDIA as the template for"
+                              " medium directly instead. DO NOT USE THIS"
+                              " OPTION UNLESS YOU REALLY KNOW WHAT YOU ARE"
+                             " DOING. THIS WILL ALTER THE ORIGINAL MEDIUM!"))
+    parser.add_argument(metavar="INPUT_MEDIUM",
+                        nargs='?', dest="medium", type=str, default=None,
+                        help=("Use INPUT_MEDIUM as the template for"
                               " Image creation, e.g., /dev/sdc, /disk0.vmdk."
                               " Specify a single slash character (/) to bundle"
                               " the filesystem of the host itself."))
@@ -296,7 +296,7 @@ def main():
         # Save the terminal attributes
         attr = termios.tcgetattr(sys.stdin.fileno())
         try:
-            ret = dialog_main(args.media, logfile=logfile, tmpdir=args.tmpdir,
+            ret = dialog_main(args.medium, logfile=logfile, tmpdir=args.tmpdir,
                               snapshot=args.snapshot, syslog=args.syslog)
         finally:
             # Restore the terminal attributes. If an error occurs make sure

--- a/image_creator/dialog_main.py
+++ b/image_creator/dialog_main.py
@@ -32,7 +32,7 @@ import traceback
 import tempfile
 
 from image_creator import __version__ as version
-from image_creator.util import FatalError
+from image_creator.util import FatalError, ensure_root
 from image_creator.output.cli import SimpleOutput
 from image_creator.output.dialog import GaugeOutput
 from image_creator.output.composite import CompositeOutput
@@ -245,10 +245,6 @@ def dialog_main(media, **kwargs):
 
 def main():
     """Entry Point"""
-    if os.geteuid() != 0:
-        sys.stderr.write("Error: You must run %s as root\n" % PROGNAME)
-        sys.exit(2)
-
     usage = "Usage: %prog [options] [<input_media>]"
     parser = optparse.OptionParser(version=version, usage=usage)
     parser.add_option("-l", "--logfile", type="string", dest="logfile",
@@ -266,8 +262,10 @@ def main():
 
     opts, args = parser.parse_args(sys.argv[1:])
 
+    ensure_root(PROGNAME)
+
     if len(args) > 1:
-        parser.error("Wrong number of arguments")
+        parser.error("Too many arguments. Please see output of `--help'.")
 
     media = args[0] if len(args) == 1 else None
 

--- a/image_creator/dialog_main.py
+++ b/image_creator/dialog_main.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""This module is the entrance point for the dialog-based version of the
+"""This module is the entry point for the dialog-based version of the
 snf-image-creator program. The main function will create a dialog where the
 user is asked if he wants to use the program in expert or wizard mode.
 """
@@ -244,7 +244,7 @@ def dialog_main(media, **kwargs):
 
 
 def main():
-    """Entrance Point"""
+    """Entry Point"""
     if os.geteuid() != 0:
         sys.stderr.write("Error: You must run %s as root\n" % PROGNAME)
         sys.exit(2)

--- a/image_creator/dialog_menu.py
+++ b/image_creator/dialog_menu.py
@@ -34,8 +34,7 @@ from image_creator.kamaki_wrapper import Kamaki, ClientError
 from image_creator.help import get_help_file
 from image_creator.dialog_util import SMALL_WIDTH, WIDTH, \
     update_background_title, confirm_reset, confirm_exit, Reset, \
-    extract_image, add_cloud, edit_cloud, update_sysprep_param, select_file, \
-    copy_file
+    extract_image, add_cloud, edit_cloud, update_sysprep_param, select_file
 
 CONFIGURATION_TASKS = [
     ("Partition table manipulation", ["FixPartitionTable"], lambda x: True),
@@ -979,31 +978,6 @@ def mount(session):
         os.rmdir(mpoint)
 
 
-def show_log(session):
-    """Show the current execution log"""
-
-    d = session['dialog']
-    log = session['image'].out[0].stderr
-
-    log.file.flush()
-
-    while 1:
-        code = d.textbox(log.name, title="Log", width=70, height=40,
-                         extra_button=1, extra_label="Save", ok_label="Close")
-        if code == d.DIALOG_EXTRA:
-            while 1:
-                path = select_file(d, title="Save log as...")
-                if path is None:
-                    break
-                if os.path.isdir(path):
-                    continue
-
-                if copy_file(d, log.name, path):
-                    break
-        else:
-            return
-
-
 def customization_menu(session):
     """Show image customization menu"""
     d = session['dialog']
@@ -1057,7 +1031,7 @@ def main_menu(session):
     default_item = "Customize"
 
     actions = {"Customize": customization_menu, "Register": kamaki_menu,
-               "Extract": extract_image, "Log": show_log}
+               "Extract": extract_image}
     title = "Image Creator for Synnefo (snf-image-creator v%s)" % version
     while 1:
         (code, choice) = d.menu(

--- a/image_creator/dialog_menu.py
+++ b/image_creator/dialog_menu.py
@@ -742,7 +742,7 @@ def sysprep_params(session):
 
 
 def virtio(session):
-    """Display the state of the VirtIO drivers in the media"""
+    """Display the state of the VirtIO drivers in the medium"""
 
     d = session['dialog']
     image = session['image']
@@ -758,7 +758,7 @@ def virtio(session):
 
         (code, choice) = d.menu(
             "In this menu you can see details about the installed VirtIO "
-            "drivers on the input media. Press <Info> to see more information "
+            "drivers on the input medium. Press <Info> to see more info "
             "about a specific installed driver or <Update> to install one or "
             "more new drivers.", height=16, width=WIDTH, choices=choices,
             ok_label="Info", menu_height=len(choices), cancel="Back",

--- a/image_creator/dialog_util.py
+++ b/image_creator/dialog_util.py
@@ -452,19 +452,4 @@ def update_sysprep_param(session, name, title=None):
 
     return True
 
-
-def copy_file(d, src, dest):
-    """Copy src file to dest"""
-
-    assert os.path.exists(src), "File: `%s' does not exist" % src
-
-    if os.path.exists(dest):
-        if d.yesno("File: `%s' exists! Are you sure you want to overwrite it?",
-                   defaultno=1, width=WIDTH):
-            return False
-
-    shutil.copyfile(src, dest)
-    d.msgbox("File: `%s' was successfully written!")
-    return True
-
 # vim: set sta sts=4 shiftwidth=4 sw=4 et ai :

--- a/image_creator/dialog_wizard.py
+++ b/image_creator/dialog_wizard.py
@@ -376,7 +376,7 @@ def start_wizard(session):
             dialog = session['dialog']
             title = "VirtIO driver missing"
             msg = "Image creation cannot proceed unless a VirtIO %s driver " \
-                  "is installed on the media!"
+                  "is installed on the medium."
             if not (viostor or new_viostor):
                 dialog.msgbox(msg % "Block Device", width=PAGE_WIDTH,
                               height=PAGE_HEIGHT, title=title)

--- a/image_creator/disk.py
+++ b/image_creator/disk.py
@@ -59,14 +59,14 @@ def get_tmp_dir(default=None):
 class Disk(object):
     """This class represents a hard disk hosting an Operating System
 
-    A Disk instance never alters the source media it is created from.
+    A Disk instance never alters the source medium it is created from.
     Any change is done on a snapshot created by the device-mapper of
     the Linux kernel.
     """
 
     def __init__(self, source, output, tmp=None):
-        """Create a new Disk instance out of a source media. The source
-        media can be an image file, a block device or a directory.
+        """Create a new Disk instance out of a source medium. The source
+        medium can be an image file, a block device or a directory.
         """
         self._cleanup_jobs = []
         self._images = []
@@ -106,7 +106,7 @@ class Disk(object):
             self._add_cleanup(check_unlink, image)
             bundle.create_image(image)
             return image
-        raise FatalError("Using a directory as media source is supported")
+        raise FatalError("Using a directory as medium source is supported")
 
     def cleanup(self):
         """Cleanup internal data. This needs to be called before the
@@ -125,12 +125,12 @@ class Disk(object):
 
     @property
     def file(self):
-        """Convert the source media into a file."""
+        """Convert the source medium into a file."""
 
         if self._file is not None:
             return self._file
 
-        self.out.info("Examining source media `%s' ..." % self.source, False)
+        self.out.info("Examining source medium `%s' ..." % self.source, False)
         mode = os.stat(self.source).st_mode
         if stat.S_ISDIR(mode):
             self.out.success('looks like a directory')
@@ -139,7 +139,7 @@ class Disk(object):
             self.out.success('looks like an image file')
             self._file = self.source
         elif not stat.S_ISBLK(mode):
-            raise FatalError("Invalid media source. Only block devices, "
+            raise FatalError("Invalid medium source. Only block devices, "
                              "regular files and directories are supported.")
         else:
             self.out.success('looks like a block device')
@@ -148,7 +148,7 @@ class Disk(object):
         return self._file
 
     def snapshot(self):
-        """Creates a snapshot of the original source media of the Disk
+        """Creates a snapshot of the original source medium of the Disk
         instance.
         """
 
@@ -156,10 +156,10 @@ class Disk(object):
             self.out.warn("Snapshotting ignored for host bundling mode.")
             return self.file
 
-        # Examine media file
+        # Examine medium file
         info = image_info(self.file)
 
-        self.out.info("Snapshotting media source ...", False)
+        self.out.info("Snapshotting medium source ...", False)
 
         # Create a qcow2 snapshot for image files that are not raw
         if info['format'] != 'raw':
@@ -196,10 +196,10 @@ class Disk(object):
         self.out.success('done')
         return "/dev/mapper/%s" % snapshot
 
-    def get_image(self, media, **kwargs):
+    def get_image(self, medium, **kwargs):
         """Returns a newly created Image instance."""
-        info = image_info(media)
-        image = Image(media, self.out, format=info['format'], **kwargs)
+        info = image_info(medium)
+        image = Image(medium, self.out, format=info['format'], **kwargs)
         self._images.append(image)
         image.enable()
         return image

--- a/image_creator/image.py
+++ b/image_creator/image.py
@@ -100,9 +100,9 @@ class Image(object):
             self.size = self.g.blockdev_getsize64(self.guestfs_device)
 
             if len(roots) > 1:
-                reason = "Multiple operating systems found on the media."
+                reason = "Multiple operating systems found on the medium."
             else:
-                reason = "Unable to detect any operating system on the media."
+                reason = "Unable to detect any operating system on the medium."
 
             self.set_unsupported(reason)
             return
@@ -126,7 +126,7 @@ class Image(object):
 
         self._unsupported = reason
         self.meta['UNSUPPORTED'] = reason
-        self.out.warn('Media is not supported. Reason: %s' % reason)
+        self.out.warn('Medium is not supported. Reason: %s' % reason)
 
     def is_unsupported(self):
         """Returns if this image is unsupported"""

--- a/image_creator/log.py
+++ b/image_creator/log.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015 Vangelis Koukis <vkoukis@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Setup logging: Formatters, handlers, and loggers"""
+
+import logging
+import logging.handlers
+
+
+def _get_log_format(progname, debug=False, use_syslog=False):
+    """Return an appropriate log format
+
+    Different formats ensure entries are uniformly formatted and do not
+    contain redundant information -- syslogd will log timestamps on its own.
+
+    """
+    if use_syslog:
+        fmt = progname + "[%(process)d]: "
+    else:
+        fmt = "%(asctime)-15s " + progname + " pid=%(process)-6d "
+
+    if debug:
+        fmt += "%(module)s:%(lineno)s "
+
+    fmt += "[%(levelname)s] %(message)s"
+
+    return fmt
+
+
+def SetupLogging(progname, debug=False, logfile=None, redirect_stderr_fd=False,
+                 use_syslog=False, syslog_facility=None):
+    """Configure the logging module.
+
+    If debug is False (default) log messages of level INFO and higher,
+    otherwise log all messages.
+
+    If logfile is specified, use it to log messages of the appropriate level,
+    according to the setting of debug.
+
+    If redirect_stderr_fd is True, also redirect stderr (fd 2) to logfile.
+    This ensures the log captures the stderr of child processes and the Python
+    interpreter itself.
+
+    Finally, if use_syslog is True, also log to syslog using the facility
+    specified via syslog_facility, or LOG_USER if left unspecified.
+
+    Note more logging points may be added in the future by using
+    root_handler.add_handler() repeatedly.
+
+    """
+
+    # File and syslog formatters
+    file_formatter = logging.Formatter(_get_log_format(progname, debug,
+                                                       False))
+    syslog_formatter = logging.Formatter(_get_log_format(progname, debug,
+                                                         True))
+
+    # Root logger
+    root_logger = logging.getLogger("")
+    root_logger.setLevel(logging.NOTSET)  # Process all log messages by default
+
+    level = logging.NOTSET if debug else logging.INFO
+
+    for handler in root_logger.handlers:
+        handler.close()
+        root_logger.removeHandler(handler)
+
+    # Syslog handler
+    if use_syslog:
+        facility = (syslog_facility if syslog_facility is not None
+                    else logging.handlers.SysLogHandler.LOG_USER)
+        # We hardcode address `/dev/log' for now, i.e., deliver to local
+        # syslogd.
+        #
+        # The local administrator can impose whatevery policy they wish
+        # by configuring the local syslogd, e.g., to forward logs
+        # to a remote syslog server.
+        syslog_handler = logging.handlers.SysLogHandler(address="/dev/log",
+                                                        facility=facility)
+        syslog_handler.setFormatter(syslog_formatter)
+        syslog_handler.setLevel(level)
+        root_logger.addHandler(syslog_handler)
+
+    # File handler
+    if logfile is not None:
+        logfile_handler = logging.FileHandler(logfile, "a")
+        logfile_handler.setFormatter(file_formatter)
+        logfile_handler.setLevel(level)
+        root_logger.addHandler(logfile_handler)
+
+    # Redirect standard error at the OS level, to catch all error output,
+    # including that of child processes and the Python interpreter itself
+    if redirect_stderr_fd:
+        os.dup2(logfile_handler.stream.fileno(), 1)
+
+# vim: set sta sts=4 shiftwidth=4 sw=4 et ai :

--- a/image_creator/main.py
+++ b/image_creator/main.py
@@ -22,7 +22,7 @@ snf-image-creator program.
 
 from image_creator import __version__ as version
 from image_creator.disk import Disk
-from image_creator.util import FatalError
+from image_creator.util import FatalError, ensure_root
 from image_creator.output.cli import SilentOutput, SimpleOutput, \
     OutputWthProgress
 from image_creator.output.composite import CompositeOutput
@@ -38,6 +38,8 @@ import textwrap
 import tempfile
 import subprocess
 import time
+
+PROGNAME = os.path.basename(sys.argv[0])
 
 
 def check_writable_dir(option, opt_str, value, parser):
@@ -222,9 +224,7 @@ def parse_options(input_args):
 def image_creator(options, out):
     """snf-mkimage main function"""
 
-    if os.geteuid() != 0:
-        raise FatalError("You must run %s as root"
-                         % os.path.basename(sys.argv[0]))
+    ensure_root(PROGNAME)
 
     # Check if the authentication info is valid. The earlier the better
     if options.token is not None and options.url is not None:

--- a/image_creator/main.py
+++ b/image_creator/main.py
@@ -57,7 +57,7 @@ def check_writable_dir(option, opt_str, value, parser):
 
 def parse_options(input_args):
     """Parse input parameters"""
-    usage = "Usage: %prog [options] <input_media>"
+    usage = "Usage: %prog [options] <input_medium>"
     parser = optparse.OptionParser(version=version, usage=usage)
 
     parser.add_option("-a", "--authentication-url", dest="url", type="string",
@@ -65,7 +65,7 @@ def parse_options(input_args):
                       "uploading/registering images")
 
     parser.add_option("--allow-unsupported", dest="allow_unsupported",
-                      help="proceed with the image creation even if the media "
+                      help="proceed with image creation even if the medium "
                       "is not supported", default=False, action="store_true")
 
     parser.add_option("-c", "--cloud", dest="cloud", type="string",
@@ -75,11 +75,11 @@ def parse_options(input_args):
 
     parser.add_option("--disable-sysprep", dest="disabled_syspreps",
                       help="prevent SYSPREP operation from running on the "
-                      "input media", default=[], action="append",
+                      "input medium", default=[], action="append",
                       metavar="SYSPREP")
 
     parser.add_option("--enable-sysprep", dest="enabled_syspreps", default=[],
-                      help="run SYSPREP operation on the input media",
+                      help="run SYSPREP operation on the input medium",
                       action="append", metavar="SYSPREP")
 
     parser.add_option("-f", "--force", dest="force", default=False,
@@ -87,8 +87,8 @@ def parse_options(input_args):
                       help="overwrite output files if they exist")
 
     parser.add_option("--host-run", dest="host_run", default=[],
-                      help="mount the media in the host and run a script "
-                      "against the guest media. This option may be defined "
+                      help="mount the medium in the host and run a script "
+                      "against the guest medium. This option may be defined "
                       "multiple times. The script's working directory will be "
                       "the guest's root directory. BE CAREFUL! DO NOT USE "
                       "ABSOLUTE PATHS INSIDE THE SCRIPT! YOU MAY HARM YOUR "
@@ -103,8 +103,8 @@ def parse_options(input_args):
                       action="append", metavar="KEY=VALUE")
 
     parser.add_option("--no-snapshot", dest="snapshot", default=True,
-                      help="don't snapshot the input media. (THIS IS "
-                      "DANGEROUS AS IT WILL ALTER THE ORIGINAL MEDIA!!!)",
+                      help="don't snapshot the input medium. (THIS IS "
+                      "DANGEROUS AS IT WILL ALTER THE ORIGINAL MEDIUM!!!)",
                       action="store_false")
 
     parser.add_option("--no-sysprep", dest="sysprep", default=True,
@@ -121,12 +121,12 @@ def parse_options(input_args):
 
     parser.add_option("--print-syspreps", dest="print_syspreps", default=False,
                       help="print the enabled and disabled system preparation "
-                      "operations for this input media", action="store_true")
+                      "operations for this input medium", action="store_true")
 
     parser.add_option("--print-sysprep-params", dest="print_sysprep_params",
                       default=False, action="store_true",
                       help="print the defined system preparation parameters "
-                      "for this input media")
+                      "for this input medium")
 
     parser.add_option("--public", dest="public", default=False,
                       help="register image with the cloud as public",
@@ -165,7 +165,7 @@ def parse_options(input_args):
 
     options.source = args[0]
     if not os.path.exists(options.source):
-        parser.error("Input media `%s' is not accessible" % options.source)
+        parser.error("Input medium `%s' is not accessible" % options.source)
 
     if options.register and not options.upload:
         parser.error("You also need to set -u when -r option is set")
@@ -275,15 +275,15 @@ def image_creator(options, out):
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
     try:
-        # There is no need to snapshot the media if it was created by the Disk
+        # There is no need to snapshot the medium if it was created by the Disk
         # instance as a temporary object.
         device = disk.file if not options.snapshot else disk.snapshot()
         image = disk.get_image(device, sysprep_params=options.sysprep_params)
 
         if image.is_unsupported() and not options.allow_unsupported:
             raise FatalError(
-                "The media seems to be unsupported.\n\n" +
-                textwrap.fill("To create an image from an unsupported media, "
+                "The medium seems to be unsupported.\n\n" +
+                textwrap.fill("To create an image from an unsupported medium, "
                               "you'll need to use the`--allow-unsupported' "
                               "command line option. Using this is highly "
                               "discouraged, since the resulting image will "
@@ -291,7 +291,7 @@ def image_creator(options, out):
                               "not get customized during the deployment."))
 
         if len(options.host_run) != 0 and not image.mount_local_support:
-            raise FatalError("Running scripts against the guest media is not "
+            raise FatalError("Running scripts against the guest medium is not "
                              "supported for this build of libguestfs.")
 
         if len(options.host_run) != 0:
@@ -337,12 +337,12 @@ def image_creator(options, out):
             image.os.install_virtio_drivers()
 
         if len(options.host_run) != 0:
-            out.info("Running scripts on the input media:")
+            out.info("Running scripts on the input medium:")
             mpoint = tempfile.mkdtemp()
             try:
                 image.mount(mpoint)
                 if not image.is_mounted():
-                    raise FatalError("Mounting the media on the host failed.")
+                    raise FatalError("Mounting the medium on the host failed.")
                 try:
                     size = len(options.host_run)
                     cnt = 1
@@ -357,7 +357,7 @@ def image_creator(options, out):
                         cnt += 1
                 finally:
                     while not image.umount():
-                        out.warn("Unable to umount the media. Retrying ...")
+                        out.warn("Unable to umount the medium. Retrying ...")
                         time.sleep(1)
                     out.info()
             finally:

--- a/image_creator/main.py
+++ b/image_creator/main.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""This module is the entrance point for the non-interactive version of the
+"""This module is the entry point for the non-interactive version of the
 snf-image-creator program.
 """
 

--- a/image_creator/os_type/__init__.py
+++ b/image_creator/os_type/__init__.py
@@ -307,7 +307,7 @@ class OSBase(object):
         del self._cleanup_jobs[namespace]
 
     def inspect(self):
-        """Inspect the media to check if it is supported"""
+        """Inspect the medium to check if it is supported"""
 
         if self.image.is_unsupported():
             return
@@ -454,7 +454,7 @@ class OSBase(object):
 
         if self.image.is_unsupported():
             self.out.warn(
-                "System preparation is disabled for unsupported media")
+                "System preparation is disabled for unsupported medium")
             return
 
         enabled = [s for s in self.list_syspreps() if self.sysprep_enabled(s)]
@@ -499,7 +499,7 @@ class OSBase(object):
             """The Mount context manager"""
             def __enter__(self):
                 mount_type = 'read-only' if readonly else 'read-write'
-                output("Mounting the media %s ..." % mount_type, False)
+                output("Mounting the medium %s ..." % mount_type, False)
 
                 parent._mount_error = ""
                 del parent._mount_warnings[:]
@@ -511,7 +511,7 @@ class OSBase(object):
                     raise
 
                 if not parent.ismounted:
-                    msg = "Unable to mount the media %s. Reason: %s" % \
+                    msg = "Unable to mount the medium %s. Reason: %s" % \
                         (mount_type, parent._mount_error)
                     if fatal:
                         raise FatalError(msg)
@@ -525,7 +525,7 @@ class OSBase(object):
                     success('done')
 
             def __exit__(self, exc_type, exc_value, traceback):
-                output("Umounting the media ...", False)
+                output("Umounting the medium ...", False)
                 parent.image.g.umount_all()
                 parent._mounted = False
                 success('done')

--- a/image_creator/os_type/freebsd.py
+++ b/image_creator/os_type/freebsd.py
@@ -50,7 +50,7 @@ class Freebsd(Bsd):
         return sshd_enabled
 
     def _do_inspect(self):
-        """Run various diagnostics to check if media is supported"""
+        """Run various diagnostics to check if medium is supported"""
 
         self.out.info('Checking partition table type...', False)
         ptype = self.image.g.part_get_parttype(self.image.guestfs_device)

--- a/image_creator/os_type/linux.py
+++ b/image_creator/os_type/linux.py
@@ -440,16 +440,16 @@ class Linux(Unix):
         return orig, dev, mpoint
 
     def _do_inspect(self):
-        """Run various diagnostics to check if media is supported"""
+        """Run various diagnostics to check if medium is supported"""
 
         self.out.info(
-            'Checking if the media contains logical volumes (LVM)...', False)
+            'Checking if the medium contains logical volumes (LVM)...', False)
 
         has_lvm = True if len(self.image.g.lvs()) else False
 
         if has_lvm:
             self.out.info()
-            self.image.set_unsupported('The media contains logical volumes')
+            self.image.set_unsupported('The medium contains logical volumes')
         else:
             self.out.success('no')
 

--- a/image_creator/os_type/slackware.py
+++ b/image_creator/os_type/slackware.py
@@ -41,7 +41,7 @@ class Slackware(Linux):
         if self.image.g.is_file(name):
             return self.image.g.stat(name)['mode'] & 0400
 
-        self.out.warn('Service %s not found on the media' % service)
+        self.out.warn('Service %s not found on the medium' % service)
         return False
 
 # vim: set sta sts=4 shiftwidth=4 sw=4 et ai :

--- a/image_creator/os_type/unsupported.py
+++ b/image_creator/os_type/unsupported.py
@@ -27,11 +27,11 @@ class Unsupported(OSBase):
 
     def collect_metadata(self):
         """Collect metadata about the OS"""
-        self.out.warn("Unable to collect metadata for unsupported media")
+        self.out.warn("Unable to collect metadata for unsupported medium")
 
     def _do_mount(self, readonly):
         """Mount partitions in correct order"""
-        self._mount_error = "not supported for this media"
+        self._mount_error = "not supported for this medium"
         return False
 
 # vim: set sta sts=4 shiftwidth=4 sw=4 et ai :

--- a/image_creator/os_type/windows/__init__.py
+++ b/image_creator/os_type/windows/__init__.py
@@ -271,7 +271,7 @@ class Windows(OSBase):
         self.registry = Registry(self.image)
 
         with self.mount(readonly=True, silent=True):
-            self.out.info("Checking media state ...", False)
+            self.out.info("Checking medium state ...", False)
 
             # Enumerate the windows users
             (self.usernames,
@@ -429,7 +429,7 @@ class Windows(OSBase):
 
         querymax = int(querymax)
         if querymax == 0:
-            self.out.warn("Unable to reclaim any space. The media is full.")
+            self.out.warn("Unable to reclaim any space. The medium is full.")
             return
 
         # Not sure if we should use 1000 or 1024 here
@@ -469,7 +469,7 @@ class Windows(OSBase):
 
         if rc != 0:
             raise FatalError(
-                "Shrinking failed. Please make sure the media is defragged.")
+                "Shrinking failed. Please make sure the medium is defragged.")
 
         for line in stdout.splitlines():
             if line.find("%d" % querymax) >= 0:
@@ -490,23 +490,23 @@ class Windows(OSBase):
 
         if self.sysprepped:
             raise FatalError(
-                "Microsoft's System Preparation Tool has ran on the media. "
+                "Microsoft's System Preparation Tool has ran on the medium. "
                 "Further image customization is not possible.")
 
         if len(self.virtio_state['viostor']) == 0:
             raise FatalError(
-                "The media has no VirtIO SCSI controller driver installed. "
+                "The medium has no VirtIO SCSI controller driver installed. "
                 "Further image customization is not possible.")
 
         if len(self.virtio_state['netkvm']) == 0:
             raise FatalError(
-                "The media has no VirtIO Ethernet Adapter driver installed. "
+                "The medium has no VirtIO Ethernet Adapter driver installed. "
                 "Further image customization is not possible.")
 
         timeout = self.sysprep_params['boot_timeout'].value
         shutdown_timeout = self.sysprep_params['shutdown_timeout'].value
 
-        self.out.info("Preparing media for boot ...", False)
+        self.out.info("Preparing medium for boot ...", False)
 
         with self.mount(readonly=False, silent=True):
 
@@ -601,7 +601,7 @@ class Windows(OSBase):
         finally:
             self.image.enable_guestfs()
 
-            self.out.info("Reverting media boot preparations ...", False)
+            self.out.info("Reverting medium boot preparations ...", False)
             with self.mount(readonly=False, silent=True, fatal=False):
 
                 if not self.ismounted:
@@ -780,7 +780,7 @@ class Windows(OSBase):
 
     def compute_virtio_state(self, directory=None):
         """Returns information about the VirtIO drivers found either in a
-        directory or the media itself if the directory is None.
+        directory or the medium itself if the directory is None.
         """
         state = {}
         for driver in VIRTIO:
@@ -817,7 +817,7 @@ class Windows(OSBase):
 
     def _fetch_virtio_drivers(self, dirname):
         """Examines a directory for VirtIO drivers and returns only the drivers
-        that are suitable for this media.
+        that are suitable for this medium.
         """
         collection = self.compute_virtio_state(dirname)
 
@@ -829,7 +829,7 @@ class Windows(OSBase):
             for inf, content in drvs.items():
                 valid = True
                 found_match = False
-                # Check if the driver is suitable for the input media
+                # Check if the driver is suitable for the input medium
                 for target in content['TargetOSVersions']:
                     if len(target) > len(self.windows_version):
                         match = target.startswith(self.windows_version)
@@ -863,8 +863,8 @@ class Windows(OSBase):
         return collection
 
     def install_virtio_drivers(self, upgrade=True):
-        """Install new VirtIO drivers on the input media. If upgrade is True,
-        then the old drivers found in the media will be removed.
+        """Install new VirtIO drivers on the input medium. If upgrade is True,
+        then the old drivers found in the medium will be removed.
         """
 
         dirname = self.sysprep_params['virtio'].value
@@ -1048,7 +1048,7 @@ class Windows(OSBase):
         self._boot_virtio_vm()
 
     def _boot_virtio_vm(self):
-        """Boot the media and install the VirtIO drivers"""
+        """Boot the medium and install the VirtIO drivers"""
 
         old_windows = self.check_version(6, 1) <= 0
         self.image.disable_guestfs()

--- a/image_creator/util.py
+++ b/image_creator/util.py
@@ -23,6 +23,7 @@ import sh
 import time
 import os
 import re
+import sys
 import json
 import tempfile
 
@@ -131,6 +132,12 @@ def virtio_versions(virtio_state):
         ret[name] = "<not found>" if len(infs) == 0 else ", ".join(vers)
 
     return ret
+
+
+def ensure_root(progname):
+    if os.geteuid() != 0:
+        sys.stderr.write("Error: %s requires root privileges\n" % progname)
+        sys.exit(2)
 
 
 class QemuNBD(object):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     license='GNU GPLv3',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['sh', 'ansicolors', 'progress>=1.0.2', 'kamaki>=0.9'],
+    install_requires=['sh', 'ansicolors', 'progress>=1.0.2', 'kamaki>=0.9',
+                      'argparse'],
     # Unresolvable dependencies:
     #   pysendfile|py-sendfile, hivex, guestfs, parted, rsync,
     entry_points={


### PR DESCRIPTION
Make various fixes throughout the code.
Convert argument-parsing to python-argparse, improve help messages.
Use separate logging procedure, separate it from interacting with the user (Output classes).
Use it to introduce the support for debugging messages throughout the code.
Use a persistent logfile, ensure all errors are logged.
This is a work-in-progress.

The end goal is to unify all frontends into a single framework:

To create an Image is to run a series of steps. Each step has input, output, and depends on other steps. Each step modifies global state (image context). Create a single framework for executing steps, which will be able to detect dependencies between the steps, and run them either in an unattended fashion, or with manual interaction.

Finally, make the functionality of Output classes completely distinct, so a single codebase can run either with manual intervention and a dialog-based frontend (the current snf-image-creator), or with minimal intervention and a text-based frontend (the current snf-mkimage), or any other combination in between.
