### PR TITLE
syslinux fixes

### DIFF
--- a/image_creator/bootloader.py
+++ b/image_creator/bootloader.py
@@ -57,7 +57,7 @@ MBR_LDR = [
     # Paragon Partition Manager
     "paragon",
     # Testdisk MBR
-    "testdist",
+    "testdisk",
     # GAG Graphical Boot Manager
     "gag",
     # BootIt Boot Manager

--- a/image_creator/image.py
+++ b/image_creator/image.py
@@ -269,18 +269,21 @@ class Image(object):
 
     def _last_partition(self):
         """Return the last partition of the image disk"""
-        if self.meta['PARTITION_TABLE'] not in 'msdos' 'gpt':
-            msg = "Unsupported partition table: %s. Only msdos and gpt " \
-                "partition tables are supported" % self.meta['PARTITION_TABLE']
-            raise FatalError(msg)
 
         def is_extended(partition):
+            """Returns True if the partition is an extended partition"""
             return self.g.part_get_mbr_id(
                 self.guestfs_device, partition['part_num']) in (0x5, 0xf)
 
         def is_logical(partition):
+            """Returns True if the partition is a logical partition"""
             return self.meta['PARTITION_TABLE'] == 'msdos' and \
                 partition['part_num'] > 4
+
+        if self.meta['PARTITION_TABLE'] not in 'msdos' 'gpt':
+            msg = "Unsupported partition table: %s. Only msdos and gpt " \
+                "partition tables are supported" % self.meta['PARTITION_TABLE']
+            raise FatalError(msg)
 
         partitions = self.g.part_list(self.guestfs_device)
         last_partition = partitions[-1]
@@ -296,32 +299,18 @@ class Image(object):
 
         return last_partition
 
-    def shrink(self, silent=False):
-        """Shrink the image.
+    def _resize_partition(self, end):
+        """Resize a partition to a new boundary"""
 
-        This is accomplished by shrinking the last file system of the
-        image and then updating the partition table. The shrinked device is
-        returned.
-
-        ATTENTION: make sure umount is called before shrink
-        """
-        def get_fstype(partition):
-            """Get file system type"""
-            device = "%s%d" % (self.guestfs_device, partition['part_num'])
-            return self.g.vfs_type(device)
+        def is_extended(partition):
+            """Returns True if the partition is an extended partition"""
+            return self.g.part_get_mbr_id(
+                self.guestfs_device, partition['part_num']) in (0x5, 0xf)
 
         def is_logical(partition):
             """Returns True if the partition is a logical partition"""
             return self.meta['PARTITION_TABLE'] == 'msdos' and \
                 partition['part_num'] > 4
-
-        def is_extended(partition):
-            """Returns True if the partition is an extended partition"""
-            if self.meta['PARTITION_TABLE'] == 'msdos':
-                mbr_id = self.g.part_get_mbr_id(self.guestfs_device,
-                                                partition['part_num'])
-                return mbr_id in (0x5, 0xf)
-            return False
 
         def part_add(ptype, start, stop):
             """Add partition"""
@@ -346,6 +335,76 @@ class Image(object):
         def part_set_bootable(partnum, bootable):
             """Sets the bootable flag for a partition"""
             self.g.part_set_bootable(self.guestfs_device, partnum, bootable)
+
+        last_part = self._last_partition()
+        sector_size = self.g.blockdev_getss(self.guestfs_device)
+        start = last_part['part_start'] / sector_size
+
+        if is_logical(last_part):
+            partitions = self.g.part_list(self.guestfs_device)
+
+            logical = []  # logical partitions
+            for partition in partitions:
+                if partition['part_num'] < 4:
+                    continue
+                logical.append({
+                    'num': partition['part_num'],
+                    'start': partition['part_start'] / sector_size,
+                    'end': partition['part_end'] / sector_size,
+                    'id': part_get_id(partition['part_num']),
+                    'bootable': part_get_bootable(partition['part_num'])
+                })
+
+            logical[-1]['end'] = end  # new end after resize
+
+            # Recreate the extended partition
+            extended = filter(is_extended, partitions)[0]
+            part_del(extended['part_num'])
+            part_add('e', extended['part_start'] / sector_size, end)
+
+            # Create all the logical partitions back
+            for l in logical:
+                part_add('l', l['start'], l['end'])
+                part_set_id(l['num'], l['id'])
+                part_set_bootable(l['num'], l['bootable'])
+        else:
+            # Recreate the last partition
+            if self.meta['PARTITION_TABLE'] == 'msdos':
+                last_part['id'] = part_get_id(last_part['part_num'])
+
+            last_part['bootable'] = part_get_bootable(last_part['part_num'])
+            part_del(last_part['part_num'])
+            part_add('p', start, end)
+            part_set_bootable(last_part['part_num'], last_part['bootable'])
+
+            if self.meta['PARTITION_TABLE'] == 'msdos':
+                part_set_id(last_part['part_num'], last_part['id'])
+
+    def shrink(self, silent=False):
+        """Shrink the image.
+
+        This is accomplished by shrinking the last file system of the
+        image and then updating the partition table. The shrinked device is
+        returned.
+
+        ATTENTION: make sure umount is called before shrink
+        """
+        def get_fstype(partition):
+            """Get file system type"""
+            device = "%s%d" % (self.guestfs_device, partition['part_num'])
+            return self.g.vfs_type(device)
+
+        def is_extended(partition):
+            """Returns True if the partition is an extended partition"""
+            if self.meta['PARTITION_TABLE'] == 'msdos':
+                mbr_id = self.g.part_get_mbr_id(self.guestfs_device,
+                                                partition['part_num'])
+                return mbr_id in (0x5, 0xf)
+            return False
+
+        def part_del(partnum):
+            """Delete a partition"""
+            self.g.part_del(self.guestfs_device, partnum)
 
         MB = 2 ** 20
 
@@ -423,45 +482,7 @@ class Image(object):
         start = last_part['part_start'] / sector_size
         end = start + (block_size * block_cnt) / sector_size - 1
 
-        if is_logical(last_part):
-            partitions = self.g.part_list(self.guestfs_device)
-
-            logical = []  # logical partitions
-            for partition in partitions:
-                if partition['part_num'] < 4:
-                    continue
-                logical.append({
-                    'num': partition['part_num'],
-                    'start': partition['part_start'] / sector_size,
-                    'end': partition['part_end'] / sector_size,
-                    'id': part_get_id(partition['part_num']),
-                    'bootable': part_get_bootable(partition['part_num'])
-                })
-
-            logical[-1]['end'] = end  # new end after resize
-
-            # Recreate the extended partition
-            extended = filter(is_extended, partitions)[0]
-            part_del(extended['part_num'])
-            part_add('e', extended['part_start'] / sector_size, end)
-
-            # Create all the logical partitions back
-            for l in logical:
-                part_add('l', l['start'], l['end'])
-                part_set_id(l['num'], l['id'])
-                part_set_bootable(l['num'], l['bootable'])
-        else:
-            # Recreate the last partition
-            if self.meta['PARTITION_TABLE'] == 'msdos':
-                last_part['id'] = part_get_id(last_part['part_num'])
-
-            last_part['bootable'] = part_get_bootable(last_part['part_num'])
-            part_del(last_part['part_num'])
-            part_add('p', start, end)
-            part_set_bootable(last_part['part_num'], last_part['bootable'])
-
-            if self.meta['PARTITION_TABLE'] == 'msdos':
-                part_set_id(last_part['part_num'], last_part['id'])
+        self._resize_partition(end)
 
         # Enlarge the underlying file system to consume the available space
         self.g.resize2fs(part_dev)

--- a/image_creator/os_type/linux.py
+++ b/image_creator/os_type/linux.py
@@ -18,11 +18,15 @@
 """This module hosts OS-specific code for Linux."""
 
 import os
+import os.path
 import re
 import pkg_resources
 import tempfile
 import yaml
+from collections import namedtuple
 
+from image_creator.util import FatalError
+from image_creator.bootloader import vbr_bootinfo
 from image_creator.os_type.unix import Unix, sysprep, add_sysprep_param
 
 X2GO_DESKTOPSESSIONS = {
@@ -73,6 +77,21 @@ class Linux(Unix):
         self._uuid = dict()
         self._persistent = re.compile('/dev/[hsv]d[a-z][1-9]*')
         self.cloud_init = False
+
+        # As of 4.00, *SYSLINUX* will search for extlinux.conf then
+        # syslinux.cfg in each directory before falling back to the next
+        # directory
+        #
+        # http://repo.or.cz/syslinux.git/blob/syslinux-6.01: \
+        #        /txt/syslinux.cfg.txt#l32
+        #
+        dirs = ('/boot/extlinux/', '/boot/syslinux/', '/boot/',
+                '/extlinux/', '/syslinux/', '/')
+        files = ('extlinux.conf', 'syslinux.cfg')
+
+        paths = ["%s%s" % (d, c) for d in dirs for c in files]
+        self.syslinux = namedtuple(
+            'syslinux', ['search_dirs', 'search_paths'])(dirs, paths)
 
     def get_cloud_init_config_files(self):
         """Returns the cloud-init configuration files of the image"""
@@ -408,6 +427,86 @@ class Linux(Unix):
 
         if self.image.g.is_file('/var/lib/dbus/machine-id'):
             self.image.g.truncate('/var/lib/dbus/machine-id')
+
+    @sysprep('Shrinking image (may take a while)', nomount=True)
+    def _shrink(self):
+        """Shrink the last file system and update the partition table"""
+        device = self.image.shrink()
+        self.shrinked = True
+
+        if not device:
+            # Shrinking failed. No need to proceed.
+            return
+
+        # Check the Volume Boot Record of the shrinked partition to determine
+        # if a bootloader is present on it.
+        vbr = self.image.g.pread_device(device, 512, 0)
+        bootloader = vbr_bootinfo(vbr)
+
+        if bootloader == 'syslinux':
+            # EXTLINUX needs to be reinstalled after shrinking
+
+            with self.mount(silent=True):
+                basedir = self._get_syslinux_base_dir()
+
+                self.out.info("Updating the EXTLINUX installation under %s ..."
+                              % basedir, False)
+                self.image.g.command(['extlinux', '-U', basedir])
+                self.out.success("done")
+
+    def _get_syslinux_base_dir(self):
+        """Find the installation directory we need to use to when updating
+        syslinux
+        """
+        cfg = None
+
+        for path in self.syslinux.search_paths:
+            if self.image.g.is_file(path):
+                cfg = path
+            break
+
+        if not cfg:
+            # Maybe we should fail here
+            self.out.warn("Unable to find syslinux configuration file!")
+            return "/boot"
+
+        kernel_regexp = re.compile(r'\s*kernel\s+(.+)', re.IGNORECASE)
+        initrd_regexp = re.compile(r'\s*initrd\s+(.+)', re.IGNORECASE)
+        append_regexp = re.compile(
+            r'\s*[Aa][Pp][Pp][Ee][Nn][Dd]\s+.*\binitrd=([^\s]+)')
+
+        kernel = None
+        initrd = None
+
+        for line in self.image.g.cat(cfg).splitlines():
+            kernel_match = kernel_regexp.match(line)
+            if kernel_match:
+                kernel = kernel_match.group(1).strip()
+                continue
+
+            initrd_match = initrd_regexp.match(line)
+            if initrd_match:
+                initrd = initrd_match.group(1).strip()
+                continue
+
+            append_match = append_regexp.match(line)
+            if append_match:
+                initrd = append_match.group(1)
+
+        if kernel and kernel[0] != '/':
+            relative_path = kernel
+        elif initrd and initrd[0] != '/':
+            relative_path = initrd
+        else:
+            # The config does not contain relative paths. Use the directory of
+            # the config.
+            return os.path.dirname(cfg)
+
+        for d in self.syslinux.search_dirs:
+            if self.image.g.is_file(d+relative_path):
+                return d
+
+        raise FatalError("Unable to find the working directory of extlinux")
 
     def _persistent_grub1(self, new_root):
         """Replaces non-persistent device name occurrences with persistent


### PR DESCRIPTION
* Leave some space when shrinking ext? file systems.
* Fix a bug in the extlinux installation code that had to do with the detection of the current working directory
* Make the _bootmenu_timeout() and _use_persistent_block_device_names() syspreps work with EXTLINUX
* Do some cleanup
